### PR TITLE
Correction to mc.cores argument for Windows compat

### DIFF
--- a/R/bootstrap-functions.R
+++ b/R/bootstrap-functions.R
@@ -54,7 +54,7 @@
 #' @rdname bootstrap
 #' @importFrom parallel mclapply
 #' @export
-bootstrap <- function(x, fun, n=1000L, mc.cores=getOption("mc.cores", 2L)) {
+bootstrap <- function(x, fun, n=1000L, mc.cores=1) {
   fun <- match.fun(fun)
 
   origin <- .clust(x, fun=fun)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ```s
 install.packages("devtools")
 library("devtools")
-install_github("bootstrap", "sgibb")
+install_github("sgibb/bootstrap") #may be asked to DL Rtools for windows; no issues, just do it :)
 ```
 
 ## Example
@@ -23,7 +23,7 @@ b <- bootstrap(USArrests, fun=createHclustObject, n=100L)
 
 ## plot
 hc <- createHclustObject(USArrests)
-plot(hc)
+plot(hc) #Note add "hang=-1" for lining up the terminals
 
 ## draw bootstrap values to corresponding node
 bootlabels.hclust(hc, b, col="blue")


### PR DESCRIPTION
Ignore the slight mods in the text of Readme. My main commit is re parallel processing in the main bootstrap function. Needed it recently, made the revision for myself, figured I'd share since the function is pretty useful. My foray into GitHub, so please don't judge if this is the wrong way to do things. 